### PR TITLE
docs(api): add initial API documentation using Bruno

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Wait for Services to Start
         run: sleep 30
 
-      - name: Run unit tests
+      - name: Run unit testsa
         run: yarn test
       
       - name: Install Bruno CLI
@@ -56,13 +56,17 @@ jobs:
         working-directory: src/api-collection
         run: npm install
 
+      - name: Check if API is up
+        run: curl --fail http://localhost:3333/sessions || (echo "API is not up!" && exit 1)
+
       - name: Create Bruno .env file
         working-directory: src/api-collection
         run: |
           touch .env
-          echo "$ENV_FILE" > .env
+          echo "$BRUNO_ENV_FILE" > .env
+          cat .env
         env:
-          ENV_FILE: ${{ secrets.BRUNO_ENV_FILE }}
+          BRUNO_ENV_FILE: ${{ secrets.BRUNO_ENV_FILE }}
 
       - name: Run Bruno API tests
         working-directory: src/api-collection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,18 +45,6 @@ jobs:
 
       - name: Wait for Services to Start
         run: sleep 30
-
-      - name: Show application logs
-        run: tail -n 50 app.log
-
-      - name: Check if API is up
-        run: |
-          curl -X POST http://localhost:3333/sessions \
-          -H "Content-Type: application/json" \
-          -d '{"email":"admin@rentapi.com.br","password":"123456"}'
-
-      - name: Run unit testsa
-        run: yarn test
       
       - name: Install Bruno CLI
         run: npm install -g @usebruno/cli
@@ -64,15 +52,6 @@ jobs:
       - name: Install Bruno test dependencies
         working-directory: src/api-collection
         run: npm install
-
-      - name: Create Bruno .env file
-        working-directory: src/api-collection
-        run: |
-          touch .env
-          echo "$BRUNO_ENV_FILE" > .env
-          cat .env
-        env:
-          BRUNO_ENV_FILE: ${{ secrets.BRUNO_ENV_FILE }}
 
       - name: Run Bruno API tests
         working-directory: src/api-collection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         run: yarn build
 
       - name: Docker compose up
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Wait for Services to Start
         run: sleep 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run Bruno API tests
         working-directory: src/api-collection
-        run: bru run . --env local --delay=1800
+        run: bru run --env local --delay=1800
 
       - name: Copy file via ssh key
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,10 +41,19 @@ jobs:
         run: yarn seed:admin
 
       - name: Run application
-        run: yarn dev &
+        run: nohup yarn dev > app.log 2>&1 &
 
       - name: Wait for Services to Start
         run: sleep 30
+
+      - name: Show application logs
+        run: tail -n 50 app.log
+
+      - name: Check if API is up
+        run: |
+          curl -X POST http://localhost:3333/sessions \
+          -H "Content-Type: application/json" \
+          -d '{"email":"admin@rentapi.com.br","password":"123456"}'
 
       - name: Run unit testsa
         run: yarn test
@@ -55,12 +64,6 @@ jobs:
       - name: Install Bruno test dependencies
         working-directory: src/api-collection
         run: npm install
-
-      - name: Check if API is up
-        run: |
-          curl -X POST http://localhost:3333/sessions \
-          -H "Content-Type: application/json" \
-          -d '{"email":"admin@rentapi.com.br","password":"123456"}'
 
       - name: Create Bruno .env file
         working-directory: src/api-collection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches: [ main ]
-    
-    
+  pull_request:
+    branches: [ main ]    
   workflow_dispatch:
 
 jobs:
@@ -46,9 +46,28 @@ jobs:
       - name: Wait for Services to Start
         run: sleep 30
 
-      - name: Run tests
+      - name: Run unit tests
         run: yarn test
       
+      - name: Install Bruno CLI
+        run: npm install -g @usebruno/cli
+
+      - name: Install Bruno test dependencies
+        working-directory: src/api-collection
+        run: npm install
+
+      - name: Create Bruno .env file
+        working-directory: src/api-collection
+        run: |
+          touch .env
+          echo "$ENV_FILE" > .env
+        env:
+          ENV_FILE: ${{ secrets.BRUNO_ENV_FILE }}
+
+      - name: Run Bruno API tests
+        working-directory: src/api-collection
+        run: bru run . --env local.bru --delay=1800
+
       - name: Copy file via ssh key
         uses: appleboy/scp-action@v0.1.4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,10 @@ jobs:
         run: npm install
 
       - name: Check if API is up
-        run: curl --fail http://localhost:3333/sessions || (echo "API is not up!" && exit 1)
+        run: |
+          curl -X POST http://localhost:3333/sessions \
+          -H "Content-Type: application/json" \
+          -d '{"email":"admin@rentapi.com.br","password":"123456"}'
 
       - name: Create Bruno .env file
         working-directory: src/api-collection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run Bruno API tests
         working-directory: src/api-collection
-        run: bru run . --env local.bru --delay=1800
+        run: bru run --env local --delay=1800
 
       - name: Copy file via ssh key
         uses: appleboy/scp-action@v0.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Run Bruno API tests
         working-directory: src/api-collection
-        run: bru run --env local --delay=1800
+        run: bru run . --env local --delay=1800
 
       - name: Copy file via ssh key
         uses: appleboy/scp-action@v0.1.4

--- a/app.log
+++ b/app.log
@@ -1,0 +1,2 @@
+nohup: ignoring input
+nohup: failed to run command 'yarn': No such file or directory

--- a/src/api-collection/Authentication/Login with credentials.bru
+++ b/src/api-collection/Authentication/Login with credentials.bru
@@ -25,3 +25,40 @@ vars:post-response {
 assert {
   res.status: eq 200
 }
+
+docs {
+  ## POST /sessions
+  
+  Endpoint de autenticação. Retorna o token JWT e dados do usuário autenticado.
+  
+  ---
+  
+  ### Requisição
+  **Method:** POST  
+  **URL:** `{{baseUrl}}/sessions`  
+  **Headers:**  
+  `Content-Type: application/json`
+  
+  **Body:**
+  ```json
+  {
+    "email": "{{email}}",
+    "password": "{{password}}"
+  }
+  ```
+  
+  ---
+  
+  ### Resposta esperada
+  ```json
+  {
+  {
+    "token": "string",
+    "user": {
+      "name": "string",
+      "email": "string"
+    },
+    "refresh_token": "string"
+  }
+  ```
+}

--- a/src/api-collection/Authentication/Login with credentials.bru
+++ b/src/api-collection/Authentication/Login with credentials.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Login with credentials
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/sessions
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "email": "{{email}}",
+    "password": "{{password}}"
+  }
+}
+
+vars:post-response {
+  refreshToken: res.body.refresh_token
+  token: res.body.token
+}
+
+assert {
+  res.status: eq 200
+}

--- a/src/api-collection/Authentication/Refresh Token.bru
+++ b/src/api-collection/Authentication/Refresh Token.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Refresh Token
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/refresh-token
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "token": "{{refreshToken}}"
+  }
+}
+
+vars:post-response {
+  token: res.body.token
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:pre-request {
+  const loginRequest = "Authentication/Login with credentials";
+  await bru.runRequest(loginRequest);
+}

--- a/src/api-collection/Authentication/folder.bru
+++ b/src/api-collection/Authentication/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Authentication
+  seq: 1
+}

--- a/src/api-collection/Authentication/folder.bru
+++ b/src/api-collection/Authentication/folder.bru
@@ -1,4 +1,4 @@
 meta {
   name: Authentication
-  seq: 1
+  seq: 2
 }

--- a/src/api-collection/Cars/Create a car.bru
+++ b/src/api-collection/Cars/Create a car.bru
@@ -33,17 +33,9 @@ assert {
 script:pre-request {
   const { faker } = require('@faker-js/faker');
   
-  // (async function setup() {
-  // //  await bru.runRequest("Authentication/Login with credentials");
-  //     console.log("Executing START....")
-  //   await bru.runRequest("Category/Create a category");
-  //   await bru.runRequest("Category/List all categories");
-  //   console.log("Executing END....")
-  // })();
-  
   const nameCarValue = faker.vehicle.model();
   await bru.setVar("nameCar",nameCarValue);
-  const categoryId = await bru.getVar("categoryId");
+  const categoryId = bru.getVar("categoryId");
   
   const dailyRate = parseFloat(faker.finance.amount());
   const fineAmount = parseFloat(faker.finance.amount());
@@ -68,53 +60,45 @@ script:post-response {
 }
 
 tests {
-  const Ajv = require('ajv');
-  const ajv = new Ajv();
+  const tv4 = require("tv4");
   
-  const schema = {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-      "id": { "type": "string" },
-      "available": { "type": "boolean" },
-      "name": { "type": "string" },
-      "description": { "type": "string" },
-      "daily_rate": { "type": "number" },
-      "license_plate": { "type": "string" },
-      "fine_amount": { "type": "number" },
-      "brand": { "type": "string" },
-      "category_id": { "type": "string" },
-      "created_at": { "type": "string" }
-    },
-    "required": [
-      "id",
-      "available",
-      "name",
-      "description",
-      "daily_rate",
-      "license_plate",
-      "fine_amount",
-      "brand",
-      "category_id",
-      "created_at"
-    ]
-  };
+  test("POST /users should return a valid car object", function () {
+    const schema = {
+      type: "object",
+      required: [
+        "id",
+        "available",
+        "name",
+        "description",
+        "daily_rate",
+        "license_plate",
+        "fine_amount",
+        "brand",
+        "created_at"
+      ],
+      properties: {
+        id: { type: "string", minLength: 1 },
+        available: { type: "boolean" },
+        name: { type: "string" },
+        description: { type: "string" },
+        daily_rate: { type: "number" },
+        license_plate: { type: "string" },
+        fine_amount: { type: "number" },
+        brand: { type: "string" },
+        category_id: { type: "string" },
+        created_at: { type: "string", format: "date-time" }
+      }
+    };
   
-  test("status code", function() {
-    expect(res.getStatus()).to.equal(201);
+    const result = tv4.validateResult(res.getBody(), schema);
+    expect(result.valid, result.error && result.error.message).to.be.true;
   });
   
-  test("verify JSON returns the right schema", function() {
-    const data = res.getBody();
-    const valid = ajv.validate(schema, data);
+  test("car name should match input", function () {
+    const expectedName = bru.getVar("nameCar");
+    const actualName = res.getBody().name;
   
-    if (!valid) {
-      console.log("❌ Schema inválido:", ajv.errors);
-    } else {
-      console.log("✅ Schema válido!");
-    }
-  
-    expect(valid).to.be.true;
+    expect(actualName).to.equal(expectedName);
   });
   
 }

--- a/src/api-collection/Cars/Create a car.bru
+++ b/src/api-collection/Cars/Create a car.bru
@@ -1,0 +1,120 @@
+meta {
+  name: Create a car
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/cars
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "name": "",
+    "description": "",
+    "daily_rate": "",
+    "license_plate": "",
+    "fine_amount": "",
+    "brand": "",
+    "category_id": ""
+  }
+}
+
+assert {
+  res.status: eq 201
+}
+
+script:pre-request {
+  const { faker } = require('@faker-js/faker');
+  
+  // (async function setup() {
+  // //  await bru.runRequest("Authentication/Login with credentials");
+  //     console.log("Executing START....")
+  //   await bru.runRequest("Category/Create a category");
+  //   await bru.runRequest("Category/List all categories");
+  //   console.log("Executing END....")
+  // })();
+  
+  const nameCarValue = faker.vehicle.model();
+  await bru.setVar("nameCar",nameCarValue);
+  const categoryId = await bru.getVar("categoryId");
+  
+  const dailyRate = parseFloat(faker.finance.amount());
+  const fineAmount = parseFloat(faker.finance.amount());
+  const data = {
+    name: nameCarValue,
+    description: faker.lorem.words(5),
+    daily_rate: dailyRate,
+    license_plate: faker.string.alphanumeric(6),
+    fine_amount: fineAmount,
+    brand: faker.vehicle.manufacturer(),
+    category_id: categoryId,
+  };
+  
+  req.setBody(data);
+  
+}
+
+script:post-response {
+  
+  
+  
+}
+
+tests {
+  const Ajv = require('ajv');
+  const ajv = new Ajv();
+  
+  const schema = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "id": { "type": "string" },
+      "available": { "type": "boolean" },
+      "name": { "type": "string" },
+      "description": { "type": "string" },
+      "daily_rate": { "type": "number" },
+      "license_plate": { "type": "string" },
+      "fine_amount": { "type": "number" },
+      "brand": { "type": "string" },
+      "category_id": { "type": "string" },
+      "created_at": { "type": "string" }
+    },
+    "required": [
+      "id",
+      "available",
+      "name",
+      "description",
+      "daily_rate",
+      "license_plate",
+      "fine_amount",
+      "brand",
+      "category_id",
+      "created_at"
+    ]
+  };
+  
+  test("status code", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("verify JSON returns the right schema", function() {
+    const data = res.getBody();
+    const valid = ajv.validate(schema, data);
+  
+    if (!valid) {
+      console.log("❌ Schema inválido:", ajv.errors);
+    } else {
+      console.log("✅ Schema válido!");
+    }
+  
+    expect(valid).to.be.true;
+  });
+  
+}

--- a/src/api-collection/Cars/List all cars available.bru
+++ b/src/api-collection/Cars/List all cars available.bru
@@ -1,0 +1,24 @@
+meta {
+  name: List all cars available
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/cars/available
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:pre-request {
+  // const loginRequest = "Authentication/Login with credentials";
+  // await bru.runRequest(loginRequest);
+}

--- a/src/api-collection/Cars/folder.bru
+++ b/src/api-collection/Cars/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Cars
+  seq: 4
+}

--- a/src/api-collection/Category/Create a category.bru
+++ b/src/api-collection/Category/Create a category.bru
@@ -1,7 +1,7 @@
 meta {
   name: Create a category
   type: http
-  seq: 1
+  seq: 2
 }
 
 post {
@@ -29,13 +29,34 @@ assert {
 script:pre-request {
   const { faker } = require('@faker-js/faker');
   
-  // const loginRequest = "Authentication/Login with credentials";
-  // await bru.runRequest(loginRequest);
+  const requestPathName = "Authentication/Refresh Token";
+  await bru.runRequest(
+     requestPathName
+  );
   
   const data = {
-    name: faker.vehicle.type() + faker.number.binary(255),
+    name: faker.vehicle.type() + faker.lorem.word(),
     description: faker.lorem.sentence()
   };
   
   req.setBody(data);
+  
+  
+}
+
+script:post-response {
+  const response = res.body;
+  const requestPathName = "Category/List all categories";
+  
+  if(res.status === 201){
+    const responseGetAllCategories = await bru.runRequest(
+     requestPathName
+  );
+  const allCategories = responseGetAllCategories.data;
+    const lastCategory = allCategories[allCategories.length - 1];
+    bru.setVar("lastCategoryId", lastCategory.id);
+    console.log("Última categoria ID:", lastCategory.id);
+  }else{
+    console.error("A categoria não foi criada, motivo: \n" + res.body.message);
+  }
 }

--- a/src/api-collection/Category/Create a category.bru
+++ b/src/api-collection/Category/Create a category.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Create a category
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/categories
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "name": "{{name}}",
+    "description": "{{description}}"
+  }
+  
+}
+
+assert {
+  res.status: eq 201
+}
+
+script:pre-request {
+  const { faker } = require('@faker-js/faker');
+  
+  // const loginRequest = "Authentication/Login with credentials";
+  // await bru.runRequest(loginRequest);
+  
+  const data = {
+    name: faker.vehicle.type() + faker.number.binary(255),
+    description: faker.lorem.sentence()
+  };
+  
+  req.setBody(data);
+}

--- a/src/api-collection/Category/Create a category.bru
+++ b/src/api-collection/Category/Create a category.bru
@@ -29,11 +29,6 @@ assert {
 script:pre-request {
   const { faker } = require('@faker-js/faker');
   
-  const requestPathName = "Authentication/Refresh Token";
-  await bru.runRequest(
-     requestPathName
-  );
-  
   const data = {
     name: faker.vehicle.type() + faker.lorem.word(),
     description: faker.lorem.sentence()
@@ -42,21 +37,4 @@ script:pre-request {
   req.setBody(data);
   
   
-}
-
-script:post-response {
-  const response = res.body;
-  const requestPathName = "Category/List all categories";
-  
-  if(res.status === 201){
-    const responseGetAllCategories = await bru.runRequest(
-     requestPathName
-  );
-  const allCategories = responseGetAllCategories.data;
-    const lastCategory = allCategories[allCategories.length - 1];
-    bru.setVar("lastCategoryId", lastCategory.id);
-    console.log("Última categoria ID:", lastCategory.id);
-  }else{
-    console.error("A categoria não foi criada, motivo: \n" + res.body.message);
-  }
 }

--- a/src/api-collection/Category/List all categories.bru
+++ b/src/api-collection/Category/List all categories.bru
@@ -1,7 +1,7 @@
 meta {
   name: List all categories
   type: http
-  seq: 2
+  seq: 3
 }
 
 get {
@@ -12,15 +12,50 @@ get {
 
 assert {
   res.status: eq 200
-}
-
-script:pre-request {
-  // const loginRequest = "Authentication/Login with credentials";
-  // await bru.runRequest(loginRequest);
+  res.body.length: gt 0
+  res.body[0].id: isDefined
+  res.body[0].created_at: matches ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$
+  res.body[0].description: isString
 }
 
 script:post-response {
   const data = res.body;
   const randomCategory = data[Math.floor(Math.random() * data.length)];
   bru.setVar("categoryId", randomCategory.id);
+}
+
+tests {
+  const tv4 = require("tv4");
+  test("should be able to login", function () {
+    expect(res.getStatus()).to.equal(200);
+  });
+  test("should return a non-empty array", function () {
+    expect(res.getBody()).to.be.an("array").that.is.not.empty;
+  });
+  test("each category should have id, name, description and created_at", function () {
+    res.getBody().forEach(cat => {
+      expect(cat).to.have.property("id");
+      expect(cat).to.have.property("name");
+      expect(cat).to.have.property("description");
+      expect(cat).to.have.property("created_at");
+    });
+  });
+  test("response matches JSON schema", function () {
+    const schema = {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["id", "name", "description", "created_at"],
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          description: { type: "string" },
+          created_at: { type: "string", format: "date-time" }
+        }
+      }
+    };
+  
+    const result = tv4.validateResult(res.getBody(), schema);
+    expect(result.valid).to.be.true;
+  });
 }

--- a/src/api-collection/Category/List all categories.bru
+++ b/src/api-collection/Category/List all categories.bru
@@ -1,0 +1,26 @@
+meta {
+  name: List all categories
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{baseUrl}}/categories
+  body: none
+  auth: none
+}
+
+assert {
+  res.status: eq 200
+}
+
+script:pre-request {
+  // const loginRequest = "Authentication/Login with credentials";
+  // await bru.runRequest(loginRequest);
+}
+
+script:post-response {
+  const data = res.body;
+  const randomCategory = data[Math.floor(Math.random() * data.length)];
+  bru.setVar("categoryId", randomCategory.id);
+}

--- a/src/api-collection/Category/folder.bru
+++ b/src/api-collection/Category/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: Category
+  seq: 3
+}

--- a/src/api-collection/bruno.json
+++ b/src/api-collection/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "api-collection",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/src/api-collection/environments/local.bru
+++ b/src/api-collection/environments/local.bru
@@ -1,5 +1,5 @@
 vars {
-  baseUrl: http://localhost:3333
   password: {{process.env.PASSWORD}}
   email: {{process.env.EMAIL}}
+  baseUrl: {{process.env.BASE_URL}}
 }

--- a/src/api-collection/environments/local.bru
+++ b/src/api-collection/environments/local.bru
@@ -1,5 +1,5 @@
 vars {
-  password: {{process.env.PASSWORD}}
-  email: {{process.env.EMAIL}}
-  baseUrl: http://18.231.189.148
+  password: 123456
+  email: admin@rentapi.com.br
+  baseUrl: http://localhost:3333
 }

--- a/src/api-collection/environments/local.bru
+++ b/src/api-collection/environments/local.bru
@@ -1,0 +1,5 @@
+vars {
+  baseUrl: http://localhost:3333
+  password: {{process.env.PASSWORD}}
+  email: {{process.env.EMAIL}}
+}

--- a/src/api-collection/environments/local.bru
+++ b/src/api-collection/environments/local.bru
@@ -1,5 +1,5 @@
 vars {
   password: {{process.env.PASSWORD}}
   email: {{process.env.EMAIL}}
-  baseUrl: {{process.env.BASE_URL}}
+  baseUrl: http://18.231.189.148
 }

--- a/src/api-collection/package-lock.json
+++ b/src/api-collection/package-lock.json
@@ -1,0 +1,84 @@
+{
+  "name": "api-collection",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "api-collection",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ajv": "^8.17.1"
+      },
+      "devDependencies": {
+        "@faker-js/faker": "^9.8.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.8.0.tgz",
+      "integrity": "sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/src/api-collection/package.json
+++ b/src/api-collection/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "api-collection",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@faker-js/faker": "^9.8.0"
+  },
+  "dependencies": {
+    "ajv": "^8.17.1"
+  }
+}

--- a/src/shared/infra/http/app.ts
+++ b/src/shared/infra/http/app.ts
@@ -56,4 +56,8 @@ app.use((err: Error, request: Request, response: Response, next: NextFunction) =
     })
 });
 
+app.get('/swagger.json', (req, res) => {
+  res.send(swaggerFile);
+});
+
 export { app }

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -2,12 +2,8 @@
     "openapi": "3.0.0",
     "info":{
         "title": "API Documentation",
-        "description": "Welcome to the Rental Services API",
-        "version": "1.0.0",
-        "contact": {
-            "name": "Amanda Stecz",
-            "url": "https://www.linkedin.com/in/amanda-c-stecz-antunes-2b298b123/"
-        }
+        "description": "Welcome to the Rental Services API by Amanda Stecz \n\n [/swagger.json](../swagger.json)",
+        "version": "1.0.0"
     },
     "paths": {
         "/sessions":{


### PR DESCRIPTION
This PR adds initial API documentation using the [Bruno API Client](https://www.usebruno.com/), enabling developers to explore and test endpoints locally with a consistent, version-controlled collection.

### What's included
- Endpoints grouped by feature (e.g., Cars, Categories, Auth)
- Token-based authentication setup
- Example requests for creating and listing resources

### Why Bruno?
Using Bruno allows us to:
- Keep API requests in source control
- Share a consistent testing environment across the team
- Easily onboard new developers with ready-to-use collections